### PR TITLE
Add function as children pattern support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,25 @@ export default React.createClass({
 });
 ```
 
+## Function as children usage
+
+```js
+import PageVisibility from 'react-page-visibility';
+
+export default React.createClass({
+    render() {
+        return (
+            <PageVisibility>
+                {visible => <RotatingCarousel rotate={visible} />}
+            </PageVisibility>
+        );
+    },
+});
+```
+
 ## API
 
-`react-page-visibility` is an higher order component which **requires** you to pass it an `onChange` function:
+`react-page-visibility` is an higher order component, you can pass to it an `onChange` function:
 
 `onChange(handler)`
 
@@ -76,6 +92,12 @@ Where `handler` is the callback to run when the `visibilityState` of the documen
 
 - `visibilityState` is a String and can be one of `visible`, `hidden`, `prerender`, `unloaded` (if your browser supports those)
 - `documentHidden` is a Boolean indicating whether document is considered hidden to the user.
+
+Or you can use [function as children](https://reactpatterns.com/#function-as-children) pattern, Where `children` is the callback to run when the `visibilityState` of the document changes.
+
+`Function children(<Boolean> documentHidden)`
+- `documentHidden` is a Boolean indicating whether document is considered hidden to the user.
+
 
 See [MDN Page Visibility API Properties overview](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API#Properties_overview)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-page-visibility",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Declarative, nested, stateful, isomorphic page visibility for React",
   "author": "Gilad Peleg <giladp007@gmail.com> (http://giladpeleg.com)",
   "repository": "pgilad/react-page-visibility",

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,14 @@ export const getVisibilityState = ({ hidden, state }) => {
 };
 
 class PageVisibility extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            visible: true
+        };
+    }
+
     componentWillMount() {
         if (!isSupported || !visibility) {
             return;
@@ -68,12 +76,22 @@ class PageVisibility extends Component {
 
     handleVisibilityChange() {
         const { hidden, state } = visibility;
-        this.props.onChange(document[state], document[hidden]);
+
+        if (typeof this.props.onChange === 'function') {
+            this.props.onChange(document[state], document[hidden]);
+        }
+
+        this.setState({ visible: !document[hidden] });
     }
 
     render() {
         if (!this.props.children) {
             return null;
+        }
+
+        // Function as children pattern support
+        if (typeof this.props.children === 'function') {
+            return this.props.children(this.state.visible);
         }
 
         return React.Children.only(this.props.children);
@@ -83,7 +101,11 @@ class PageVisibility extends Component {
 PageVisibility.displayName = 'PageVisibility';
 
 PageVisibility.propTypes = {
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func,
+    children: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.func
+    ])
 };
 
 export default PageVisibility;


### PR DESCRIPTION
Hello,
This PR add support of [children as function](https://reactpatterns.com/#function-as-children) pattern support, for more declarative usage possibility:

```jsx
import PageVisibility from 'react-page-visibility';

export default () => (
  <PageVisibility>
    {visible => <RotatingCarousel rotate={visible} />}
  </PageVisibility>
)
```

instead of setStates/callbacks soup.