### PR TITLE
Fix componentWillMount deprecation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ class PageVisibility extends React.Component {
         };
     }
 
-    componentWillMount() {
+    componentDidMount() {
         if (!this.state.isSupported) {
             return;
         }


### PR DESCRIPTION
`componentWillMount` is deprecated and should not be used. Instead use `componentDidMount`.

https://reactjs.org/docs/react-component.html#unsafe_componentwillmount

https://github.com/facebook/react/issues/7671

Because this HOC adds an event listener, this can cause memory leaks when the component is rendered on the server, because it never unmounts.