### PR TITLE
SSR fix

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -44,6 +44,7 @@ export const visibility = (() => {
 })();
 
 export const getHandlerArgs = () => {
+    if (!visibility) return [true, () => {}];
     const { hidden, state } = visibility;
     return [!document[hidden], document[state]];
 };


### PR DESCRIPTION
Visibility can be null when `isSupported` is false, so `getHandlerArgs` needs to make sure `visibility` is defined before accessing its keys.

In case visibility isn't defined, I think it's best to set the initial visibility state to true, especially for server rendering purposes.