### PR TITLE
chore(deps): include react 18 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "tape": "^5.0.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "prop-types": "^15.7.2"


### PR DESCRIPTION
Closes #23 
This enables using react-page-visibility in projects that already use react 18.

I couldn't find a contribution guide, so i simply opened this pull request. Happy for any feedback.

@pgilad Is there anything else to look for in a pull request? E.g. **bumping the package version** or **testing**
Also do you see any other changes that need to be done?
